### PR TITLE
Use checksum format more convient with sha512sum

### DIFF
--- a/plugins/stage-vote-release-plugin/src/main/kotlin/com/github/vlsi/gradle/release/ReleaseArtifacts.kt
+++ b/plugins/stage-vote-release-plugin/src/main/kotlin/com/github/vlsi/gradle/release/ReleaseArtifacts.kt
@@ -76,7 +76,8 @@ open class ReleaseArtifacts @Inject constructor(
                     "checksum"(
                         "file" to archiveFile.get(),
                         "algorithm" to "SHA-512",
-                        "fileext" to ".sha512"
+                        "fileext" to ".sha512",
+                        "format" to "MD5SUM"
                     )
                 }
             }


### PR DESCRIPTION
I haven't checked it, but according to the ant checksum plugin it should produce the correct file format to easily check with `sha512sum -c *.sha512`