### PR TITLE
license-gather: ignore namespaces in PomLicenseLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Change log
 ----------
 v1.78
 * chore: bump Gradle 6.7 -> 6.9.1
+* license-gather: ignore xml namespaces when parsing POM files (see #43)
 
 v1.77
 * crlf-plugin: bump jgit to 5.13.0.202109080827-r

--- a/plugins/license-gather-plugin/src/main/kotlin/com/github/vlsi/gradle/license/PomLicenseLoader.kt
+++ b/plugins/license-gather-plugin/src/main/kotlin/com/github/vlsi/gradle/license/PomLicenseLoader.kt
@@ -108,7 +108,7 @@ fun GPathResult.attr(name: String): String = get("@$name").text()
 @Suppress("UNCHECKED_CAST")
 fun GPathResult.getList(name: String) = getProperty(name) as Iterable<GPathResult>
 
-private fun File.parseXml(): GPathResult = XmlSlurper().parse(this)
+private fun File.parseXml(): GPathResult = XmlSlurper(false, false).parse(this)
 
 fun GPathResult.parsePom(): PomContents {
     fun GPathResult.parseId(parentGroup: String = "") =


### PR DESCRIPTION
Hi Vladimir,

This fixes the issue mentioned in #43