### PR TITLE
license-gather-plugin: Fixed MANIFEST check is always skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ Change log
 v1.78
 * chore: bump Gradle 6.7 -> 6.9.1
 * license-gather: ignore xml namespaces when parsing POM files (see #43)
+* license-gather: fix license inference from Bundle-License manifest attribute (see #48)
+
+Thanks to [Florian Dreier](https://github.com/DreierF) for identifying bugs and suggesting fixes.
 
 v1.77
 * crlf-plugin: bump jgit to 5.13.0.202109080827-r

--- a/plugins/license-gather-plugin/src/main/kotlin/com/github/vlsi/gradle/license/GatherLicenseTask.kt
+++ b/plugins/license-gather-plugin/src/main/kotlin/com/github/vlsi/gradle/license/GatherLicenseTask.kt
@@ -484,7 +484,7 @@ open class GatherLicenseTask @Inject constructor(
                 )
                 continue
             }
-            if (!file.endsWith(".jar")) {
+            if (file.extension != "jar") {
                 logger.debug(
                     "File {} for artifact {} does not look like a JAR. Will skip MANIFEST.MF check",
                     file,
@@ -500,7 +500,11 @@ open class GatherLicenseTask @Inject constructor(
             )
             JarFile(file).use { jar ->
                 val bundleLicense = jar.manifest.mainAttributes.getValue("Bundle-License")
-                val license = bundleLicense?.substringBefore(";")?.let {
+                if (bundleLicense == null || bundleLicense.startsWith("http://") || bundleLicense.startsWith("https://")) {
+                    // Ignore URLs here as it will fail during parsing
+                    return
+                }
+                val license = bundleLicense.substringBefore(";")?.let {
                     licenseExpressionParser.parse(it)
                 }
                 if (license != null) {

--- a/plugins/license-gather-plugin/src/main/kotlin/com/github/vlsi/gradle/license/api/OsgiBundleLicenseParser.kt
+++ b/plugins/license-gather-plugin/src/main/kotlin/com/github/vlsi/gradle/license/api/OsgiBundleLicenseParser.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Vladimir Sitnikov <sitnikov.vladimir@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.github.vlsi.gradle.license.api
+
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.net.URISyntaxException
+
+class OsgiBundleLicenseParser(
+    private val licenseExpressionParser: LicenseExpressionParser,
+    private val lookupLicenseByUri: (URI) -> LicenseExpression?
+) {
+    private val logger = LoggerFactory.getLogger(OsgiBundleLicenseParser::class.java)
+
+    fun parseOrNull(bundleLicense: String, context: Any): LicenseExpression? {
+        return if (bundleLicense.contains(',')) {
+            logger.info(
+                "Ignoring Bundle-License '{}' in {} since it contains multiple license references",
+                bundleLicense,
+                context
+            )
+            null
+        } else if (bundleLicense.startsWith("http")) {
+            // Infer license from the URI
+            val uri = try {
+                URI(bundleLicense)
+            } catch (e: URISyntaxException) {
+                logger.info(
+                    "Invalid URI for license in Bundle-License value '{}' in {}",
+                    bundleLicense,
+                    context,
+                    e
+                )
+                return null
+            }
+            lookupLicenseByUri(uri)
+        } else {
+            // Infer license from "SPDX-Expression; licenseURI"
+            // We ignore URI as the expression should be more important
+            bundleLicense.substringBefore(";").let {
+                try {
+                    licenseExpressionParser.parse(it)
+                } catch (e: ParseException) {
+                    logger.info(
+                        "Unable to parse Bundle-License value '{}' in {}",
+                        bundleLicense,
+                        context,
+                        e
+                    )
+                    null
+                }
+            }
+        }
+    }
+}

--- a/plugins/license-gather-plugin/src/test/kotlin/com/github/vlsi/gradle/license/OsgiBundleLicenseParserTest.kt
+++ b/plugins/license-gather-plugin/src/test/kotlin/com/github/vlsi/gradle/license/OsgiBundleLicenseParserTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Vladimir Sitnikov <sitnikov.vladimir@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.github.vlsi.gradle.license
+
+import com.github.vlsi.gradle.license.api.LicenseExpressionParser
+import com.github.vlsi.gradle.license.api.OsgiBundleLicenseParser
+import com.github.vlsi.gradle.license.api.SpdxLicense
+import com.github.vlsi.gradle.license.api.asExpression
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class OsgiBundleLicenseParserTest {
+    @ParameterizedTest
+    @CsvSource(
+        "license from https uri^Apache-2.0^https://www.apache.org/licenses/LICENSE-2.0",
+        "license from http uri^Apache-2.0^http://www.apache.org/licenses/LICENSE-2.0",
+        "license from https uri^Apache-1.0^https://www.apache.org/licenses/LICENSE-1.0",
+        "license from SPDX^Apache-2.0^Apache-2.0;https://www.apache.org/licenses/LICENSE-1.0",
+        "SPDX expression^Apache-1.0 OR Apache-2.0^Apache-2.0 OR Apache-1.0;https://www.apache.org/licenses/LICENSE-1.0",
+        delimiter = '^'
+    )
+    fun success(comment: String, expected: String, input: String) {
+        val parser = OsgiBundleLicenseParser(LicenseExpressionParser()) {
+            SpdxLicense.fromUriOrNull(it)?.asExpression()
+        }
+        assertEquals(expected, parser.parseOrNull(input, "test input").toString()) {
+            "$comment, input: $input"
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "unknown uri^https://www.apache.org/licenses/LICENSE-1.2",
+        "invalid expression^Apache OR;http://www.apache.org/licenses/LICENSE-2.0",
+        "multiple licenses^license1,license2",
+        "multiple licenses^Apache-2.0;https://www.apache.org/licenses/LICENSE-2.0,Apache_1.0;https://www.apache.org/licenses/LICENSE-1.0",
+        delimiter = '^'
+    )
+    fun fail(comment: String, input: String) {
+        val parser = OsgiBundleLicenseParser(LicenseExpressionParser()) {
+            SpdxLicense.fromUriOrNull(it)?.asExpression()
+        }
+        assertNull(parser.parseOrNull(input, "test input")) {
+            "$comment should cause OsgiBundleLicenseParser.parse failure, input: $input"
+        }
+    }
+}


### PR DESCRIPTION
Found this while debugging to understand how the plugin actually works. The `endsWith` extension function does not what it seems to do at first sight

```
/**
 * Determines whether this file belongs to the same root as [other]
 * and ends with all components of [other] in the same order.
 * So if [other] has N components, last N components of `this` must be the same as in [other].
 * For relative [other], `this` can belong to any root.
 *
 * @return `true` if this path ends with [other] path, `false` otherwise.
 */
public fun File.endsWith(other: String): Boolean = endsWith(File(other))
```

and therefore always evaluates to false