### PR TITLE
Adopt jandex plugin for Gradle configuration cache

### DIFF
--- a/plugins/jandex-plugin/src/main/kotlin/com/github/vlsi/jandex/JandexTask.kt
+++ b/plugins/jandex-plugin/src/main/kotlin/com/github/vlsi/jandex/JandexTask.kt
@@ -18,7 +18,9 @@ package com.github.vlsi.jandex
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileType
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Console
@@ -39,6 +41,8 @@ import javax.inject.Inject
 
 @CacheableTask
 abstract class JandexTask @Inject constructor(
+    @Input val jandexBuildAction: Property<JandexBuildAction>,
+    @OutputFile val indexFile: RegularFileProperty,
     objects: ObjectFactory
 ) : DefaultTask() {
     @get:Inject
@@ -66,14 +70,6 @@ abstract class JandexTask @Inject constructor(
     @SkipWhenEmpty
     @PathSensitive(PathSensitivity.RELATIVE)
     val inputFiles = objects.fileCollection()
-
-    @OutputFile
-    val indexFile = objects.fileProperty()
-        .convention(project.layout.buildDirectory.map { it.file("${JandexPlugin.JANDEX_TASK_NAME}/$name/jandex.idx") })
-
-    @Input
-    val jandexBuildAction = objects.property<JandexBuildAction>()
-        .convention(JandexBuildAction.BUILD_AND_INCLUDE)
 
     @TaskAction
     fun run(inputChanges: InputChanges) {


### PR DESCRIPTION
[Gradle configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html)
has been introduced with Gradle 6.5 and recently improved.

When using the jandex-plugin with
```
org.gradle.unsafe.configuration-cache=true
org.gradle.unsafe.configuration-cache-problems=warn
```
Gradle complains in the generated configuration cache report (usually under
`build/reports/configuration-cache` in the root project) about `JandexTask` and
`JandexProcessResources` keeping references to
["certain object types"](https://docs.gradle.org/7.4/userguide/configuration_cache.html#config_cache:requirements:disallowed_types)
that break the configuration cache - in this case `JandexTask` and `DefaultSourceSet`.

This change moves those types out of the serialized state of `JandexTask` and
`JandexProcessResources` and lets the `JandexPlugin` push the relevant information
using allowed types into the tasks.

Screen shot of such a config cache report without this change:
![image](https://user-images.githubusercontent.com/957468/170541500-cc11fdd7-6d4c-415e-8d09-049432bcf8bc.png)
