### PR TITLE
Migrate to the latest version of smallrye

### DIFF
--- a/plugins/jandex-plugin/src/main/kotlin/com/github/vlsi/jandex/JandexExtension.kt
+++ b/plugins/jandex-plugin/src/main/kotlin/com/github/vlsi/jandex/JandexExtension.kt
@@ -23,7 +23,7 @@ import javax.inject.Inject
 open class JandexExtension @Inject constructor(
     objects: ObjectFactory
 ) {
-    val toolVersion = objects.property<String>().convention("2.0.3.Final")
+    val toolVersion = objects.property<String>().convention("3.0.5")
     val maxErrors = objects.property<Int>().convention(1000)
     val jandexBuildAction = objects.property<JandexBuildAction>()
         .convention(JandexBuildAction.BUILD_AND_INCLUDE)

--- a/plugins/jandex-plugin/src/main/kotlin/com/github/vlsi/jandex/JandexPlugin.kt
+++ b/plugins/jandex-plugin/src/main/kotlin/com/github/vlsi/jandex/JandexPlugin.kt
@@ -39,7 +39,7 @@ open class JandexPlugin : Plugin<Project> {
             project.extensions.create(JANDEX_TASK_NAME, JandexExtension::class.java)
         val jandexClasspath = configurations.create("jandexClasspath") {
             defaultDependencies {
-                add(project.dependencies.create("org.jboss:jandex:${jandexExtension.toolVersion.get()}"))
+                add(project.dependencies.create("io.smallrye:jandex:${jandexExtension.toolVersion.get()}"))
             }
         }
 


### PR DESCRIPTION
Fixes #86 

Thee SmallRye one is the original repo, recently migrated from https://github.com/wildfly/jandex to https://github.com/smallrye/jandex. It holds the sources of what used to be org.jboss.jandex artifact group ID (and is now io.smallrye)