### PR TITLE
use printTestResult for all AbstractTestTasks

### DIFF
--- a/plugins/gradle-extensions-plugin/src/main/kotlin/com/github/vlsi/gradle/ProjectExtensionsPlugin.kt
+++ b/plugins/gradle-extensions-plugin/src/main/kotlin/com/github/vlsi/gradle/ProjectExtensionsPlugin.kt
@@ -32,7 +32,7 @@ class ProjectExtensionsPlugin : Plugin<Project> {
         if (GitHubActionsLogger.isEnabled) {
             target.gradle.addListener(PrintGitHubActionsMarkersForFailingTasks)
         }
-        target.tasks.withType<Test>().configureEach {
+        target.tasks.withType<AbstractTestTask>().configureEach {
             testLogging {
                 // Empty enum throws "Collection is empty", so we use Iterable method
                 setEvents((events - TestLogEvent.FAILED) as Iterable<TestLogEvent>)

--- a/plugins/gradle-extensions-plugin/src/main/kotlin/com/github/vlsi/gradle/test/dsl/PrintTestResults.kt
+++ b/plugins/gradle-extensions-plugin/src/main/kotlin/com/github/vlsi/gradle/test/dsl/PrintTestResults.kt
@@ -57,7 +57,7 @@ private fun StyledTextBuilder.appendTestName(name: String) {
     }
 }
 
-fun Test.printTestResults(
+fun AbstractTestTask.printTestResults(
     slowTestLogThreshold: Long = project.props.long("slowTestLogThreshold", 2000L),
     slowSuiteLogThreshold: Long = project.props.long("slowSuiteLogThreshold", 0L),
     enableColor: Boolean = !project.props.bool("nocolor",


### PR DESCRIPTION
be aware of, I did not test it and made the changes via web-gui but I hope it will serve as basis for an improvement. 
Currently, I don't see the nice prints for a kotlin JS project (and the same would be true for other targets). Unfortunately, the kotlin people decided to create test tasks for those targets which do not inherit from `Test` (no idea why):
![image](https://github.com/user-attachments/assets/5397e081-14f1-48b3-843c-5fecbfc2540a)

Using AbstractTestTask could solve this.