### PR TITLE
Replaced deprecated groovy.util usages with groovy.xml

### DIFF
--- a/plugins/license-gather-plugin/src/main/kotlin/com/github/vlsi/gradle/license/GatherLicenseTask.kt
+++ b/plugins/license-gather-plugin/src/main/kotlin/com/github/vlsi/gradle/license/GatherLicenseTask.kt
@@ -26,7 +26,7 @@ import com.github.vlsi.gradle.license.api.LicenseExpressionParser
 import com.github.vlsi.gradle.license.api.OsgiBundleLicenseParser
 import com.github.vlsi.gradle.license.api.SpdxLicense
 import com.github.vlsi.gradle.license.api.text
-import groovy.util.slurpersupport.GPathResult
+import groovy.xml.slurpersupport.GPathResult
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -53,8 +53,6 @@ import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.setProperty
 import org.gradle.kotlin.dsl.submit
-import org.gradle.util.GradleVersion
-import org.gradle.workers.IsolationMode
 import org.gradle.workers.WorkerExecutor
 import java.io.File
 import java.util.*

--- a/plugins/license-gather-plugin/src/main/kotlin/com/github/vlsi/gradle/license/MetadataStore.kt
+++ b/plugins/license-gather-plugin/src/main/kotlin/com/github/vlsi/gradle/license/MetadataStore.kt
@@ -35,8 +35,8 @@ import com.github.vlsi.gradle.license.api.StandardLicense
 import com.github.vlsi.gradle.license.api.StandardLicenseException
 import com.github.vlsi.gradle.license.api.WithException
 import com.github.vlsi.gradle.license.api.orLater
-import groovy.util.XmlSlurper
-import groovy.util.slurpersupport.GPathResult
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
 import groovy.xml.MarkupBuilder
 import org.gradle.api.GradleException
 import org.gradle.kotlin.dsl.withGroovyBuilder

--- a/plugins/license-gather-plugin/src/main/kotlin/com/github/vlsi/gradle/license/PomLicenseLoader.kt
+++ b/plugins/license-gather-plugin/src/main/kotlin/com/github/vlsi/gradle/license/PomLicenseLoader.kt
@@ -22,8 +22,8 @@ import com.github.vlsi.gradle.license.api.License
 import com.github.vlsi.gradle.license.api.LicenseExpression
 import com.github.vlsi.gradle.license.api.LicenseExpressionNormalizer
 import com.github.vlsi.gradle.license.api.SimpleLicense
-import groovy.util.XmlSlurper
-import groovy.util.slurpersupport.GPathResult
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.GradleException
 import org.gradle.api.Project

--- a/plugins/license-gather-plugin/src/test/kotlin/com/github/vlsi/gradle/license/PomParsingTest.kt
+++ b/plugins/license-gather-plugin/src/test/kotlin/com/github/vlsi/gradle/license/PomParsingTest.kt
@@ -17,7 +17,7 @@
 
 package com.github.vlsi.gradle.license
 
-import groovy.util.XmlSlurper
+import groovy.xml.XmlSlurper
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.io.StringReader

--- a/plugins/stage-vote-release-plugin/src/main/kotlin/com/github/vlsi/gradle/release/svn/Svn.kt
+++ b/plugins/stage-vote-release-plugin/src/main/kotlin/com/github/vlsi/gradle/release/svn/Svn.kt
@@ -19,8 +19,8 @@ package com.github.vlsi.gradle.release.svn
 import com.github.vlsi.gradle.license.attr
 import com.github.vlsi.gradle.license.get
 import com.github.vlsi.gradle.license.getList
-import groovy.util.XmlSlurper
-import groovy.util.slurpersupport.GPathResult
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
 import java.io.ByteArrayOutputStream
 import java.net.URI
 import java.time.OffsetDateTime


### PR DESCRIPTION
`groovy.util` is no longer available in Gradle 9.x / Groovy 4 and hence fails to instantiate the tasks using it.