### PR TITLE
Revert "fix(deps): update dependency com.squareup:kotlinpoet to v2"

### DIFF
--- a/buildSrc/subprojects/license-texts/license-texts.gradle.kts
+++ b/buildSrc/subprojects/license-texts/license-texts.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.19.1")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.19.1")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.19.1")
-    implementation("com.squareup:kotlinpoet:2.2.0")
+    implementation("com.squareup:kotlinpoet:1.18.1")
 }
 
 java {


### PR DESCRIPTION
This reverts commit 7dcef76b4bc67fe5b6f6287e914a75883041d544.

Kotlinpoet requires Kotlin 2.1 which is not available in Gradle.

See:
* https://github.com/square/kotlinpoet/issues/2151
* https://github.com/square/kotlinpoet/issues/2152