### PR TITLE
fix(stage-vote-release-plugin): avoid NPE when applied without a Git repository

### DIFF
--- a/plugins/stage-vote-release-plugin/src/main/kotlin/com/github/vlsi/gradle/release/DefaultGitTask.kt
+++ b/plugins/stage-vote-release-plugin/src/main/kotlin/com/github/vlsi/gradle/release/DefaultGitTask.kt
@@ -20,6 +20,7 @@ import com.github.vlsi.gradle.release.jgit.dsl.useRun
 import org.ajoberstar.grgit.Grgit
 import org.eclipse.jgit.api.Git
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.provider.Property
@@ -40,7 +41,11 @@ abstract class DefaultGitTask : DefaultTask() {
     abstract val rootDir: DirectoryProperty
 
     @get:Internal
-    protected val grgit = project.property("grgit") as Grgit
+    protected val grgit: Grgit
+        get() = project.findProperty("grgit") as Grgit?
+            ?: throw GradleException(
+                "Task '$name' requires a Git repository, but the project is not under Git version control"
+            )
 
     init {
         // Never up to date

--- a/plugins/stage-vote-release-plugin/src/main/kotlin/com/github/vlsi/gradle/release/ReleaseExtension.kt
+++ b/plugins/stage-vote-release-plugin/src/main/kotlin/com/github/vlsi/gradle/release/ReleaseExtension.kt
@@ -56,13 +56,13 @@ open class ReleaseExtension @Inject constructor(
     val validateNexusCredentials =
         project.validate { nexus.credentials }.toMutableList()
 
-    protected val grgit = project.property("grgit") as Grgit
+    protected val grgit: Grgit? get() = project.findProperty("grgit") as Grgit?
 
     val validateBeforeBuildingReleaseArtifacts = mutableListOf(Runnable {
         if (allowUncommittedChanges.get()) {
             return@Runnable
         }
-        val jgit = grgit.repository.jgit
+        val jgit = grgit?.repository?.jgit ?: return@Runnable
         jgit.status().call().apply {
             if (!hasUncommittedChanges()) {
                 return@Runnable

--- a/plugins/stage-vote-release-plugin/src/main/kotlin/com/github/vlsi/gradle/release/StageVoteReleasePlugin.kt
+++ b/plugins/stage-vote-release-plugin/src/main/kotlin/com/github/vlsi/gradle/release/StageVoteReleasePlugin.kt
@@ -308,7 +308,6 @@ class StageVoteReleasePlugin @Inject constructor(
         }
 
         // Validations should be performed before tasks start execution
-        val grgit = project.property("grgit") as Grgit
         project.gradle.taskGraph.whenReady {
             val validations = mutableListOf<Runnable>()
             if (hasTask(validateRcIndexSpecified.get())) {
@@ -323,6 +322,10 @@ class StageVoteReleasePlugin @Inject constructor(
                     // Tag won't be created as a part of the release
                     validations += Runnable {
                         if (releaseExt.release.get()) {
+                            val grgit = project.findProperty("grgit") as Grgit?
+                                ?: throw GradleException(
+                                    "Release tasks require a Git repository, but the project is not under Git version control"
+                                )
                             val repository = grgit.repository.jgit.repository
                             val tagName = releaseExt.rcTag.get()
                             repository.exactRef(Constants.R_TAGS + tagName)?.commitId
@@ -638,9 +641,12 @@ class StageVoteReleasePlugin @Inject constructor(
             val projectDir = layout.projectDirectory
             outputs.file(file(voteMailFile))
             val nexusPublish = project.the<NexusPublishExtension>()
-            val grgit = project.property("grgit") as Grgit
 
             doLast {
+                val grgit = project.findProperty("grgit") as Grgit?
+                    ?: throw GradleException(
+                        "$GENERATE_VOTE_TEXT_TASK_NAME requires a Git repository, but the project is not under Git version control"
+                    )
                 val nexusRepoName = REPOSITORY_NAME
                 val repositoryId = releaseExt.repositoryIdStore[nexusRepoName]
 

--- a/plugins/stage-vote-release-plugin/src/test/kotlin/com/github/vlsi/gradle/release/StageVoteReleasePluginApplyTest.kt
+++ b/plugins/stage-vote-release-plugin/src/test/kotlin/com/github/vlsi/gradle/release/StageVoteReleasePluginApplyTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Vladimir Sitnikov <sitnikov.vladimir@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.github.vlsi.gradle.release
+
+import com.github.vlsi.gradle.BaseGradleTest
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+@Execution(ExecutionMode.SAME_THREAD)
+class StageVoteReleasePluginApplyTest : BaseGradleTest() {
+    @ParameterizedTest
+    @MethodSource("disabledConfigurationCacheGradleVersionAndSettings")
+    fun pluginAppliesWithoutGitRepository(testCase: TestCase) {
+        // Reproduces https://github.com/vlsi/vlsi-release-plugins/issues/171:
+        // ASF source releases ship without .git, so applying the plugin must not
+        // throw NPE just because the project is not under Git version control.
+        createSettings(testCase)
+        projectDir.resolve("build.gradle").write(
+            """
+            plugins {
+              id 'com.github.vlsi.stage-vote-release'
+            }
+            """.trimIndent()
+        )
+        prepare(testCase, "help").build()
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the eager `project.property("grgit") as Grgit` cast with a nullable lookup, so the plugin no longer NPEs at apply time when the project has no `.git` (typical for ASF source-release tarballs)
- Skip the uncommitted-changes validation when no Git repository is available; release tasks that genuinely need Git now throw a clear `GradleException` instead
- Add a TestKit test that applies the plugin in a project without `.git` and runs `help` — this also caught the same unsafe cast in `DefaultGitTask` (affecting `pushRcTag`, `pushReleaseTag`, `gitCreateTag`, etc.)

Fixes #171

## Test plan
- [x] `./gradlew :plugins:stage-vote-release-plugin:test` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)